### PR TITLE
fixes missing libxtst6 & libxss1 for chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN  apt-get update \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \
+     && apt-get install -y libxtst6 \
+	&& apt-get install -y libxss1 \
      && apt-get install -y google-chrome-unstable --no-install-recommends \
      && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
this fixes the following issue: https://github.com/dantheman213/spotify-playlist-to-json/issues/3